### PR TITLE
Make SSM parameter module bulletproof

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,21 @@ module "ssm" {
 
   name = "example"
 
-  parameters = [
-    {
-    name        = "foo_db_endpoint"
-    description = "Endpoint URL for foo database"
+  parameters = {
+    "foo_db_endpoint" = {
+      description = "Endpoint URL for foo database"
     },
 
-    {
-    name        = "foo_db_engine"
-    description = "Engine for foo database"
-    value       = "postgres"
+    "foo_db_engine" = {
+      description = "Engine for foo database"
+      value       = "postgres"
     },
 
-    {
-    name        = "foo_db_password"
-    description = "Password for foo database"
-    type        = "SecureString"
+    "foo_db_password" = {
+      description = "Password for foo database"
+      type        = "SecureString"
     },
-  ]
+  }
 }
 ```
 
@@ -56,11 +53,11 @@ The following arguments are supported:
 parameter
 ---------
 
-A parameter block consists of a list of maps. Each map entry supports the following keys:
+A parameter block consists of a map of maps. Each map's key represents
+a parameter name. The value stored under this key consists of another
+map that may contain the following keys:
 
 * `description` – (Optional) A description of the parameter. If not specified, a default value is assigned that draws attention to the need to provide a meaningful description.
-
-* `name` – (Required) The parameter name.
 
 * `type` – (Optional) The parameter's type. The values `String` and
 `SecureString` are permissible, with `String` being the default.

--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,10 @@
 resource "aws_ssm_parameter" "default" {
-  count = length(var.parameters)
-
-  description = lookup(
-    var.parameters[count.index],
-    "description",
-    "*** NO DESCRIPTION SET ***",
-  )
-
-  name = format(
-    "%s/%s/%s",
-    var.prefix,
-    var.name,
-    var.parameters[count.index]["name"],
-  )
-
-  type  = lookup(var.parameters[count.index], "type", "String")
-  value = lookup(var.parameters[count.index], "value", "*** NO VALUE SET ***")
+  for_each = var.parameters
+  #name       = each.key
+  name        = format("%s/%s/%s", var.prefix, var.name, each.key)
+  type        = lookup(each.value, "type", "String")
+  value       = lookup(each.value, "value", "*** NO VALUE SET ***")
+  description = lookup(each.value, "description", "*** NO DESCRIPTION SET ***")
 
   lifecycle {
     # Never update the value of an existing SSM parameter.

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
-variable "parameters" {
-  description = "Parameters expressed as a list of maps, each entry of which may contain the following keys: description, name, type, and value."
-  type        = list(map(string))
-}
-
 variable "name" {
   description = "Parameter name"
+}
+
+variable "parameters" {
+  description = "Parameters expressed as a map of maps. Each map's key is its intended SSM parameter name, and the value stored under that key is another map that may contain the following keys: description, type, and value."
+  type        = map(map(string))
 }
 
 variable "prefix" {


### PR DESCRIPTION
Terraform modules using `count` are susceptible to the items in a list being shifted when any element is added or removed from the list. This takes place as a result of each element's index changing.

In the case of some resources like SSM variables, this can cause data loss. Any time an element in the middle of the list is inserted or removed, the index of each element below the removed element change; this results in the parameter being removed and then recreated. However, in the process of doing so, the parameter value (which is maintained externally in the case of sensitive data) is lost.

Module is refactored to define a map of maps instead of a list of maps. The "outer" map consists of keys representing parameter names; the values stored under each key consists of another map that may contain the keys description, type, and value.

By this technique, each SSM variable is referenced by its unique key (the variable name) rather than by an index. This should allow multiple SSM variables to be managed in a single configuration directory without risk of parameter values being lost as the result of unrelated additions or deletions to other parameters.